### PR TITLE
Adjust the rarity on the desert lands, as the set symbols indicate they aren't rare.

### DIFF
--- a/mtgen/wwwroot/akh/cardsLand.json
+++ b/mtgen/wwwroot/akh/cardsLand.json
@@ -337,7 +337,7 @@
     "addedViaException": true,
     "mtgenId": "akh|241/269",
     "set": "akh",
-    "rarity": "r"
+    "rarity": "c"
   },
   {
     "src": "http://media.wizards.com/2017/dw466ytu5_akh/en_E0w0D6sVK8.png",
@@ -348,7 +348,7 @@
     "addedViaException": true,
     "mtgenId": "akh|242/269",
     "set": "akh",
-    "rarity": "r"
+    "rarity": "c"
   },
   {
     "src": "http://media.wizards.com/2017/dw466ytu5_akh/en_lRR892wXFr.png",
@@ -372,7 +372,7 @@
     "addedViaException": true,
     "mtgenId": "akh|244/269",
     "set": "akh",
-    "rarity": "r"
+    "rarity": "u"
   },
   {
     "src": "http://media.wizards.com/2017/dw466ytu5_akh/en_nsXw6JpzGH.png",
@@ -396,7 +396,7 @@
     "addedViaException": true,
     "mtgenId": "akh|246/269",
     "set": "akh",
-    "rarity": "r"
+    "rarity": "c"
   },
   {
     "src": "http://media.wizards.com/2017/dw466ytu5_akh/en_cmJc89R9pt.png",
@@ -432,6 +432,6 @@
     "addedViaException": true,
     "mtgenId": "akh|249/269",
     "set": "akh",
-    "rarity": "r"
+    "rarity": "c"
   }
 ]


### PR DESCRIPTION
I noticed that Evolving Wilds and the desert lands occasionally replace the rare in a pack, but never appear in their respective rarity.

I went through and fixed their rarities to match what their images indicate, since I saw nothing detailing this as a feature of the set.