### PR TITLE
Manually seeding the RNG

### DIFF
--- a/mtgen/wwwroot/lib/mtg-generator-lib.js
+++ b/mtgen/wwwroot/lib/mtg-generator-lib.js
@@ -37,6 +37,9 @@ Author: Cam Marsollier cam.marsollier@gmail.com
 */
 /* jshint laxcomma: true */
 
+// seedrandom 3.0.5 taken from https://cdnjs.cloudflare.com/ajax/libs/seedrandom/3.0.5/seedrandom.min.js
+!function(f,a,c){var s,l=256,p="random",d=c.pow(l,6),g=c.pow(2,52),y=2*g,h=l-1;function n(n,t,r){function e(){for(var n=u.g(6),t=d,r=0;n<g;)n=(n+r)*l,t*=l,r=u.g(1);for(;y<=n;)n/=2,t/=2,r>>>=1;return(n+r)/t}var o=[],i=j(function n(t,r){var e,o=[],i=typeof t;if(r&&"object"==i)for(e in t)try{o.push(n(t[e],r-1))}catch(n){}return o.length?o:"string"==i?t:t+"\0"}((t=1==t?{entropy:!0}:t||{}).entropy?[n,S(a)]:null==n?function(){try{var n;return s&&(n=s.randomBytes)?n=n(l):(n=new Uint8Array(l),(f.crypto||f.msCrypto).getRandomValues(n)),S(n)}catch(n){var t=f.navigator,r=t&&t.plugins;return[+new Date,f,r,f.screen,S(a)]}}():n,3),o),u=new m(o);return e.int32=function(){return 0|u.g(4)},e.quick=function(){return u.g(4)/4294967296},e.double=e,j(S(u.S),a),(t.pass||r||function(n,t,r,e){return e&&(e.S&&v(e,u),n.state=function(){return v(u,{})}),r?(c[p]=n,t):n})(e,i,"global"in t?t.global:this==c,t.state)}function m(n){var t,r=n.length,u=this,e=0,o=u.i=u.j=0,i=u.S=[];for(r||(n=[r++]);e<l;)i[e]=e++;for(e=0;e<l;e++)i[e]=i[o=h&o+n[e%r]+(t=i[e])],i[o]=t;(u.g=function(n){for(var t,r=0,e=u.i,o=u.j,i=u.S;n--;)t=i[e=h&e+1],r=r*l+i[h&(i[e]=i[o=h&o+t])+(i[o]=t)];return u.i=e,u.j=o,r})(l)}function v(n,t){return t.i=n.i,t.j=n.j,t.S=n.S.slice(),t}function j(n,t){for(var r,e=n+"",o=0;o<e.length;)t[h&o]=h&(r^=19*t[h&o])+e.charCodeAt(o++);return S(t)}function S(n){return String.fromCharCode.apply(0,n)}if(j(c.random(),a),"object"==typeof module&&module.exports){module.exports=n;try{s=require("crypto")}catch(n){}}else"function"==typeof define&&define.amd?define(function(){return n}):c["seed"+p]=n}("undefined"!=typeof self?self:this,[],Math);
+
 // --------------------------------------------------------------------------------------------------------------------------------
 // Main module: main structure, query parser, base renderer
 // --------------------------------------------------------------------------------------------------------------------------------
@@ -52,6 +55,8 @@ var mtgGen = (function (my) {
     my.hasFactions = false;
     my.hasColleges = false;
     my.hasFamilies = false;
+    my.masterPRNG = new Math.seedrandom(); // used for creating seeds for actual generation
+    my.currentPRNG = (new Math.seedrandom()).double;
 
     my.initViews = []; // for modules to add their views to be run once at the start of the app
 
@@ -634,6 +639,14 @@ var mtgGen = (function (my) {
             });
     };
 
+    my.getRandomSeed = function () {
+        return '' + my.masterPRNG.int32();
+    };
+
+    my.seedRNG = function (seed) {
+        my.currentPRNG = (new Math.seedrandom(seed)).double;
+    };
+
     my.generateCardSetsFromPacks = function (packs) {
         // Generate the requested sets
         let generatedSets = [];
@@ -663,7 +676,7 @@ var mtgGen = (function (my) {
                 const totalWeight = cardDef.querySet[0].overrideSlot !== undefined ? 100 : cardDef.querySet.reduce((total, query) => total + query.percent, 0);
 
                 // Choose the card query percent; we want decimal numbers because the cards can be specified as such (e.g.: 1/8 chance = 12.5%)
-                let percent = Math.random() * totalWeight;
+                let percent = my.currentPRNG() * totalWeight;
                 if (percent > totalWeight) { percent = totalWeight; }
 
                 // Choose the card query that matches that weighted percentage
@@ -898,7 +911,7 @@ var mtgGen = (function (my) {
 
                 // Randomly pick a percentage within our whole.
                 const totalWeight = weightedRaritySet.reduce((total, rarity) => total + rarity.percent, 0);
-                let percent = Math.random() * totalWeight;
+                let percent = my.currentPRNG() * totalWeight;
                 if (percent > totalWeight) { percent = totalWeight; }
 
                 // Find the rarity associated with that percentage.
@@ -1182,7 +1195,7 @@ var mtgGen = (function (my) {
             max = min;
             min = 0;
         }
-        return min + Math.floor(Math.random() * (max - min + 1));
+        return min + Math.floor(my.currentPRNG() * (max - min + 1));
     }
 
     /* --------- Sorting All Cards --------------------------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
As I mentioned earlier, I've added an experimental option to seed the random number generator manually using a text field.

This allows anyone to regenerate the same packs if they specify the same seed. In particular, putting `hello.` as the seed for 1 draft booster for BRO should give you the same set of cards as in https://github.com/copperdogma/mtgen/pull/34 .

This PR is based on top of `modularity` (https://github.com/copperdogma/mtgen/pull/34), so please don't merge until the other one is merged. If you need me to change or rebase things, I'll be happy to do so.

There are a few issues:
1. The label "Seed" for the checkbox only works on the first tab. This is because the DOM contains duplicate IDs, which it should never do. Clicking on the 'Seed' text when you've got a different tab selected will toggle the checkbox on the first (then hidden) tab. I've made a FIXME comment about it too.
2. I've copy-pasted the minified `seedrandom` library verbatim because I wasn't sure how else to include it. Users of just the lib won't have the `<script>` tags. They could be told to manually include that lib before calling `mtg-generator-lib.js` or something – I'm open to suggestions.
3. I couldn't determine whether the `renderPack()` function is ever used, and if so, what logic would it use for seeding the RNG. It seems to reference sets which have button options, but the only set I could find with buttons was THS, and when I set a breakpoint for `renderPack` it was never hit. If you let me know which set(s) use it, I'll be happy to make it work.